### PR TITLE
Add option to ignore popup in path input dialog

### DIFF
--- a/main.py
+++ b/main.py
@@ -159,7 +159,7 @@ def main():
         log_level,
     )
 
-    if not snapcast_settings.should_ignore_popup():
+    if not snapcast_settings.should_ignore_popup() or os.path.exists(snapcast_settings.read_setting("Snapclient/Custom_Path")) is False:
         dialog = PathInputDialog("snapclient", log_level)
         if dialog.exec() == QDialog.Accepted:
             snapcast_settings.set_ignore_popup(dialog.ignore_popup_checkbox.isChecked())

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import sys
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import QUrl
 from PySide6.QtGui import QDesktopServices
+from PySide6.QtWidgets import QDialog
 
 from snapcast_gui.windows.combined_window import CombinedWindow
 from snapcast_gui.fileactions.file_folder_checks import FileFolderChecks
@@ -17,6 +18,7 @@ from snapcast_gui.windows.settings_window import SettingsWindow
 from snapcast_gui.fileactions.snapcast_settings import SnapcastSettings
 from snapcast_gui.misc.snapcast_gui_variables import SnapcastGuiVariables
 from snapcast_gui.misc.logger_setup import LoggerSetup
+from snapcast_gui.dialogs.path_input_dialog import PathInputDialog
 
 def read_log_level(log_level_file_path: str) -> int:
     """
@@ -156,6 +158,11 @@ def main():
         snapcast_settings,
         log_level,
     )
+
+    if not snapcast_settings.should_ignore_popup():
+        dialog = PathInputDialog("snapclient", log_level)
+        if dialog.exec() == QDialog.Accepted:
+            snapcast_settings.set_ignore_popup(dialog.ignore_popup_checkbox.isChecked())
 
     combined_window.show()
     sys.exit(app.exec())

--- a/snapcast_gui/dialogs/path_input_dialog.py
+++ b/snapcast_gui/dialogs/path_input_dialog.py
@@ -8,7 +8,9 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QPushButton,
     QVBoxLayout,
+    QCheckBox,
 )
+from snapcast_gui.fileactions.snapcast_settings import SnapcastSettings
 
 
 class PathInputDialog(QDialog):
@@ -41,6 +43,9 @@ class PathInputDialog(QDialog):
         self.browse_button.clicked.connect(self.browse_path)
         self.layout.addWidget(self.browse_button)
 
+        self.ignore_popup_checkbox = QCheckBox("Don't ask again", self)
+        self.layout.addWidget(self.ignore_popup_checkbox)
+
         self.button_box = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
         self.button_box.accepted.connect(self.accept)
@@ -70,3 +75,16 @@ class PathInputDialog(QDialog):
         """
         self.logger.debug(f"Returning path: {self.path_edit.text()}")
         return self.path_edit.text()
+
+    def accept(self) -> None:
+        """
+        Accepts the dialog and stores the user's preference for ignoring the popup.
+
+        This method is triggered when the OK button is clicked. It stores the user's
+        preference for ignoring the popup in the settings file using the SnapcastSettings
+        class and then accepts the dialog.
+        """
+        ignore_popup = self.ignore_popup_checkbox.isChecked()
+        SnapcastSettings().set_ignore_popup(ignore_popup)
+        self.logger.debug(f"Ignore popup preference set to: {ignore_popup}")
+        super().accept()

--- a/snapcast_gui/fileactions/snapcast_settings.py
+++ b/snapcast_gui/fileactions/snapcast_settings.py
@@ -34,6 +34,7 @@ class SnapcastSettings:
             "Snapclient/show_advanced_settings_on_startup": False,
             "Snapclient/enable_custom_path": False,
             "Snapclient/Custom_Path": "",
+            "Snapclient/Ignore_Popup": False,
             "Snapserver/autostart": False,
             "Snapserver/Config_Before_Start": "",
             "Snapserver/Config_After_Start": "",
@@ -173,3 +174,21 @@ class SnapcastSettings:
         self.logger.debug(
             "IP Address {} removed from config file.".format(ip)
         )
+
+    def should_ignore_popup(self) -> bool:
+        """
+        Reads the setting for ignoring the popup and returns its value.
+
+        Returns:
+            bool: True if the popup should be ignored, False otherwise.
+        """
+        return self.read_setting("Snapclient/Ignore_Popup")
+
+    def set_ignore_popup(self, value: bool) -> None:
+        """
+        Updates the setting for ignoring the popup.
+
+        Args:
+            value (bool): The new value for the setting.
+        """
+        self.update_setting("Snapclient/Ignore_Popup", value)

--- a/snapcast_gui/fileactions/snapcast_settings.py
+++ b/snapcast_gui/fileactions/snapcast_settings.py
@@ -11,7 +11,7 @@ class SnapcastSettings:
     A class that handles the settings for the Snapcast GUI application.
     """
 
-    def __init__(self, log_level: int) -> None:
+    def __init__(self, log_level: int = logging.DEBUG) -> None:
         """
         Initializes the snapcastsettings object.
 
@@ -191,4 +191,4 @@ class SnapcastSettings:
         Args:
             value (bool): The new value for the setting.
         """
-        self.update_setting("Snapclient/Ignore_Popup", value)
+        self.update_setting("Snapclient/Ignore_Popup", str(value))


### PR DESCRIPTION
Add an option to ignore the popup and not ask again in the dialog for providing the path for the snapclient.

* Add a new setting `Snapclient/Ignore_Popup` to the `ensure_settings` method in `snapcast_gui/fileactions/snapcast_settings.py`.
* Add methods `should_ignore_popup` and `set_ignore_popup` to read and update the `Snapclient/Ignore_Popup` setting in `snapcast_gui/fileactions/snapcast_settings.py`.
* Add a checkbox to the `PathInputDialog` in `snapcast_gui/dialogs/path_input_dialog.py` to allow users to ignore the popup.
* Update the `accept` method in `PathInputDialog` to store the user's preference using `SnapcastSettings`.
* Check the `Snapclient/Ignore_Popup` setting before showing the `PathInputDialog` in `main.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chicco-carone/Snapcast-Gui?shareId=6bda060c-29fd-4d95-ad42-04f76d52e233).